### PR TITLE
fix: pin anthropic version for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 uvicorn[standard]
-anthropic
+anthropic==0.26.1
 https://github.com/gptscript-ai/claude3-provider-common/archive/tool-beta.zip#0.0.2


### PR DESCRIPTION
The latest release of the anthropic sdk breaks this provider. Pin to the last working version until we can investigate whether this is an sdk bug or a breaking change we need to address.